### PR TITLE
Add ability to specify custom cache duration

### DIFF
--- a/Source/Rejuicer/Rejuicer/Engine/OutputContent.cs
+++ b/Source/Rejuicer/Rejuicer/Engine/OutputContent.cs
@@ -18,6 +18,7 @@ namespace Rejuicer.Engine
         public byte[] ContentHash { get; set; }
         public string ContentType { get; set; }
         public bool AllowClientCaching { get; set; }
+        public TimeSpan? CacheFor { get; set; }
         public DateTime LastModifiedDate { get; set; }
     }
 }

--- a/Source/Rejuicer/Rejuicer/Engine/RejuicerModule.cs
+++ b/Source/Rejuicer/Rejuicer/Engine/RejuicerModule.cs
@@ -43,7 +43,7 @@ namespace Rejuicer
 
                 if (result.AllowClientCaching)
                 {
-                    response.Expires = 525600; // Browser cache expires after one year
+                    response.Expires = (int)(result.CacheFor ?? TimeSpan.FromDays(365)).TotalMinutes; 
                     response.CacheControl = "public";
                         // Any entity can cache this - be it the browser or a proxy server
                 }

--- a/Source/Rejuicer/Rejuicer/Fluent/CompactorConfigurer.cs
+++ b/Source/Rejuicer/Rejuicer/Fluent/CompactorConfigurer.cs
@@ -64,5 +64,11 @@ namespace Rejuicer
         {
             get { _config.Context = Context.ExceptWhenDebugging; return this; }
         }
+
+        public ICompactorConfigurer CacheFor(TimeSpan cacheTime)
+        {
+            _config.CacheFor = cacheTime;
+            return this;
+        }
     }
 }

--- a/Source/Rejuicer/Rejuicer/Fluent/ICompactorConfigurer.cs
+++ b/Source/Rejuicer/Rejuicer/Fluent/ICompactorConfigurer.cs
@@ -13,6 +13,7 @@ namespace Rejuicer
         ICompactorConfigurer File(string virtualPath, Mode mode);
         IDirectoryFileMatchConfigurer FilesIn(string path);
         IDirectoryFileMatchConfigurer FilesIn(string path, Mode mode);
+        ICompactorConfigurer CacheFor(TimeSpan cacheTime);
 
         void Configure();
     }

--- a/Source/Rejuicer/Rejuicer/Model/RejuicerConfigurationSource.cs
+++ b/Source/Rejuicer/Rejuicer/Model/RejuicerConfigurationSource.cs
@@ -42,6 +42,8 @@ namespace Rejuicer.Model
 
         public Mode Mode { get; set; }
 
+        public TimeSpan? CacheFor { get; set; }
+
         public void AddRule(IContentSourceRule rule)
         {
             _lock.EnterWriteLock();
@@ -143,7 +145,8 @@ namespace Rejuicer.Model
                                       {
                                           Content = minifiedContent,
                                           ContentHash = minifiedContent.HashArray(),
-                                          AllowClientCaching = ContainsPlaceHolder,
+                                          AllowClientCaching = ContainsPlaceHolder || CacheFor.HasValue,
+                                          CacheFor = CacheFor,
                                           ContentType = minificationProvider.GetContentType(RequestFor),
                                           LastModifiedDate = content.Max(x => x.LastModifiedDate)
                                       };


### PR DESCRIPTION
Closes issue #5

Example usage:

``` csharp
OnRequest.ForJs("~/Combined/Widgets/v2.js")
    .Compact
    .File("~/Content/core.js")
    .File("~/Content/Widgets.js")
    .CacheFor(TimeSpan.FromDays(1)) // <-- This is new
    .Configure();
```
