### PR TITLE
Bugfix: accessing JS files via azure cdn

### DIFF
--- a/Source/Rejuicer/Rejuicer/HtmlHelpers/Rejuicer.cs
+++ b/Source/Rejuicer/Rejuicer/HtmlHelpers/Rejuicer.cs
@@ -49,7 +49,7 @@ namespace Rejuicer
             {
                 // Output <script src='' type=''>
                 var script = new TagBuilder("script");
-                script.Attributes.Add("src", UrlHelper.GenerateContentUrl(f, new HttpContextWrapper(HttpContext.Current)));
+                script.Attributes.Add("src", virtualPathResolver.GetRelativeUrl(f));
                 script.Attributes.Add("type", "text/javascript");
 
                 return script.ToString(TagRenderMode.Normal);


### PR DESCRIPTION
The logic to generate the urls of combined files was different between css and js.

```
string file = "~/Combined/scripts-{0}.js";
Rejuiced.JsFor(file);
```

When the url is generated via azure's cdn JsFor resulted in /cdn/Combined instead of /Combined.
The link to the CSS file was generated correctly.
