### PR TITLE
Add support for Virtual Paths as part of the application structure

### DIFF
--- a/Source/Rejuicer/Rejuicer/Engine/FileResolver.cs
+++ b/Source/Rejuicer/Rejuicer/Engine/FileResolver.cs
@@ -19,7 +19,7 @@ namespace Rejuicer
         
         public static IEnumerable<string> VirtualPathsFor(RejuicerConfigurationSource config)
         {
-            return config == null ? Enumerable.Empty<string>() : config.GetDependencies(config.ResourceType).Select(f => VirtualPathResolver.GetVirtualPathFor(f));
+            return config == null ? Enumerable.Empty<string>() : config.GetFiles(config.ResourceType);
         }
 
         private class FileComparer : IEqualityComparer<FileInfo>

--- a/Source/Rejuicer/Rejuicer/Engine/PhysicalFileRegister.cs
+++ b/Source/Rejuicer/Rejuicer/Engine/PhysicalFileRegister.cs
@@ -27,16 +27,16 @@ namespace Rejuicer.Engine
             return fileSourceRegister.ContainsKey(virtualPath) ? fileSourceRegister[virtualPath] : null;
         }
 
-        public static PhysicalFileSource For(FileInfo file, ResourceType resourceType, Mode mode)
+        public static PhysicalFileSource For(string virtualPath, ResourceType resourceType, Mode mode)
         {
-            var virtualPathFor = VirtualPathResolver.GetVirtualPathFor(file);
+            var file = new FileInfo(VirtualPathResolver.ResolveVirtualPath(virtualPath));
 
-            var physicalFileSource = For(virtualPathFor);
+            var physicalFileSource = For(virtualPath);
 
             if (physicalFileSource == null)
             {
-                physicalFileSource = new PhysicalFileSource(resourceType, 
-                                                            virtualPathFor,
+                physicalFileSource = new PhysicalFileSource(resourceType,
+                                                            virtualPath,
                                                             file.FullName,
                                                             mode);
 

--- a/Source/Rejuicer/Rejuicer/Model/IContentSource.cs
+++ b/Source/Rejuicer/Rejuicer/Model/IContentSource.cs
@@ -12,6 +12,8 @@ namespace Rejuicer.Model
         ResourceType ResourceType { get; }
         IEnumerable<FileInfo> GetDependencies(ResourceType? resourceType);
         IEnumerable<FileInfo> GetDependencies();
+        IEnumerable<string> GetFiles(ResourceType? resourceType);
+        IEnumerable<string> GetFiles();
         OutputContent GetContent(ICacheProvider cacheProvider);
     }
 }

--- a/Source/Rejuicer/Rejuicer/Model/PhysicalFileSource.cs
+++ b/Source/Rejuicer/Rejuicer/Model/PhysicalFileSource.cs
@@ -51,6 +51,31 @@ namespace Rejuicer.Model
             }
         }
 
+        public IEnumerable<string> GetFiles()
+        {
+            return GetFiles(null);
+        }
+
+        public IEnumerable<string> GetFiles(ResourceType? resourceType)
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                var dependencies = _dependencies.SelectMany(x => x.GetFiles(resourceType));
+
+                if (!resourceType.HasValue || ResourceType == resourceType.Value)
+                {
+                    dependencies = dependencies.Union(new[] { VirtualPath });
+                }
+
+                return dependencies;
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
         public OutputContent GetContent(ICacheProvider cacheProvider)
         {
             return GetContent(cacheProvider, Mode);

--- a/Source/Rejuicer/Rejuicer/Model/RejuicerConfigurationSource.cs
+++ b/Source/Rejuicer/Rejuicer/Model/RejuicerConfigurationSource.cs
@@ -98,6 +98,24 @@ namespace Rejuicer.Model
             }
         }
 
+        public IEnumerable<string> GetFiles()
+        {
+            return GetFiles(null);
+        }
+
+        public IEnumerable<string> GetFiles(ResourceType? resourceType)
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                return this.SelectMany(x => x.GetFiles(resourceType)).Distinct();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
         public DateTime GetLastModifiedDate(ICacheProvider cacheProvider)
         {
             return GetContent(cacheProvider).LastModifiedDate;

--- a/Source/Rejuicer/Rejuicer/Rules/SingleFileRule.cs
+++ b/Source/Rejuicer/Rejuicer/Rules/SingleFileRule.cs
@@ -42,7 +42,7 @@ namespace Rejuicer.Model
                 return Enumerable.Empty<IContentSource>().OrderBy(x => x);
             }
 
-            return new IContentSource[] { PhysicalFileRegister.For(file, resourceType, Mode) }.OrderBy(x => x);
+            return new IContentSource[] { PhysicalFileRegister.For(VirtualPath, resourceType, Mode) }.OrderBy(x => x);
         }
     }
 }

--- a/Source/Rejuicer/Rejuicer/Rules/WildcardMatchFileRule.cs
+++ b/Source/Rejuicer/Rejuicer/Rules/WildcardMatchFileRule.cs
@@ -51,10 +51,10 @@ namespace Rejuicer.Rules
             if (physicalPath == null)
                 return Enumerable.Empty<IContentSource>().OrderBy(x => x);
 
-            return Directory.GetFiles(physicalPath.FullName, SearchPattern ?? "*", IsRecursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+            return Directory.EnumerateFiles(physicalPath.FullName, SearchPattern ?? "*", IsRecursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
                         .Select(f => new FileInfo(f))
                         .Where(FileNotExcluded)
-                        .Select(file => PhysicalFileRegister.For(file, resourceType, Mode))
+                        .Select(file => PhysicalFileRegister.For(string.Format("{0}/{1}", FolderVirtualPath, file.Name), resourceType, Mode))
                         .OfType<IContentSource>()
                         .OrderBy(x => new FileInfo(((PhysicalFileSource)x).PhysicalPath).Name);
         }


### PR DESCRIPTION
If you have a directory structure with shared assets between projects using IIS' Virtual Path feature, Rejuicer currently generates invalid file names.

Given the following project structure:

```
CommonAssets/
  Content/
    Common/
        style.css
WebApp/
  Content/
    Common => CommonAssets/Content/Common (Virtual Path)
```

Rejuicer now generates a file name like `/monAssets/Content/Common/...` or `/tent/Common/...` (skipping parts of Content or including parts of the path to the CommonAssets project) if the folder names aren't the same length.
